### PR TITLE
remove AddDebug

### DIFF
--- a/HelloDotNet/Program.cs
+++ b/HelloDotNet/Program.cs
@@ -10,8 +10,7 @@ namespace HelloDotNet
         static void Main(string[] args)
         {
             ILoggerFactory factory = new LoggerFactory()
-              .AddConsole(LogLevel.Debug)
-              .AddDebug();
+              .AddConsole(LogLevel.Debug);
 
             Configuration ldConfig = LaunchDarkly.Client.Configuration
                     // TODO: Enter your LaunchDarkly SDK key here


### PR DESCRIPTION
On a fresh clone of this project when I try to run it I get the following error message:

```
'ILoggerFactory' does not contain a definition for 'AddDebug' and no extension method 'AddDebug' accepting a first argument of type 'ILoggerFactory' could be found (are you missing a using directive or an assembly reference?)    HelloDotNet    C:\Users\Administrator\Desktop\git\hello-dotnet\HelloDotNet\Program.cs    14    Active
```

Removing the AddDebug() option removes this error message.