### PR TITLE
update for SDK 6.0

### DIFF
--- a/HelloDotNet/Hello.cs
+++ b/HelloDotNet/Hello.cs
@@ -29,7 +29,7 @@ namespace HelloDotNet
 
             var client = new LdClient(ldConfig);
 
-            if (client.Initialized())
+            if (client.Initialized)
             {
                 ShowMessage("SDK successfully initialized!");
             }

--- a/HelloDotNet/Hello.cs
+++ b/HelloDotNet/Hello.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using Common.Logging;
-using LaunchDarkly.Client;
-using LaunchDarkly.Logging;
+using LaunchDarkly.Sdk;
+using LaunchDarkly.Sdk.Server;
 
 namespace HelloDotNet
 {
@@ -25,10 +24,6 @@ namespace HelloDotNet
                 ShowMessage("Please edit Hello.cs to set SdkKey to your LaunchDarkly SDK key first");
                 Environment.Exit(1);
             }
-
-            LogManager.Adapter = new ConsoleAdapter(LogLevel.Info);
-            // ConsoleAdapter is a simple Common.Logging implementation that's provided by LaunchDarkly;
-            // Common.Logging has an equivalent class, but not on every platform
 
             Configuration ldConfig = LaunchDarkly.Client.Configuration
                 .Default(SdkKey);

--- a/HelloDotNet/Hello.cs
+++ b/HelloDotNet/Hello.cs
@@ -25,10 +25,9 @@ namespace HelloDotNet
                 Environment.Exit(1);
             }
 
-            Configuration ldConfig = LaunchDarkly.Client.Configuration
-                .Default(SdkKey);
+            var ldConfig = Configuration.Default(SdkKey);
 
-            LdClient client = new LdClient(ldConfig);
+            var client = new LdClient(ldConfig);
 
             if (client.Initialized())
             {
@@ -42,7 +41,7 @@ namespace HelloDotNet
 
             // Set up the user properties. This user should appear on your LaunchDarkly users dashboard
             // soon after you run the demo.
-            User user = User.Builder("example-user-key")
+            var user = User.Builder("example-user-key")
                 .Name("Sandy")
                 .Build();
 

--- a/HelloDotNet/HelloDotNet.csproj
+++ b/HelloDotNet/HelloDotNet.csproj
@@ -5,6 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="6.0.0-rc.3" />
+    <!-- This dependency deliberately refers to 6.* rather than a specific
+         version, to ensure that the hello-dotnet demo always uses the latest
+         public release of the SDK. -->
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="6.*" />
   </ItemGroup>
 </Project>

--- a/HelloDotNet/HelloDotNet.csproj
+++ b/HelloDotNet/HelloDotNet.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="6.0.0-rc.1" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="6.0.0-rc.3" />
   </ItemGroup>
 </Project>

--- a/HelloDotNet/HelloDotNet.csproj
+++ b/HelloDotNet/HelloDotNet.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.*" />
-    <PackageReference Include="Common.Logging" Version="3.*" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="6.0.0-rc.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We'll merge this to master (and change the dependency from `6.0.0-rc.1` to `6.*`) once we've done the GA release.