### PR TITLE
Fix the dependency version

### DIFF
--- a/HelloDotNet/HelloDotNet.csproj
+++ b/HelloDotNet/HelloDotNet.csproj
@@ -8,6 +8,6 @@
     <!-- This dependency deliberately refers to 7.* rather than a specific
          version, to ensure that the hello-dotnet demo always uses the latest
          public release of the SDK. -->
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="7*" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="7.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We missed a dot in the version so the build was looking at version 70.x instead of 7.x