### PR TITLE
fix: Removed Unnecessary `string.Format` 

### DIFF
--- a/HelloDotNet/Hello.cs
+++ b/HelloDotNet/Hello.cs
@@ -63,8 +63,7 @@ namespace HelloDotNet
 
             var flagValue = client.BoolVariation(FeatureFlagKey, context, false);
 
-            Console.WriteLine(string.Format("*** The {0} feature flag evaluates to {1}.\n",
-                FeatureFlagKey, flagValue));
+            Console.WriteLine("*** The {0} feature flag evaluates to {1}.\n", FeatureFlagKey, flagValue);
 
             if (flagValue)
             {
@@ -75,8 +74,7 @@ namespace HelloDotNet
                 FeatureFlagKey,
                 context,
                 (sender, changeArgs) => {
-                    Console.WriteLine(string.Format("*** The {0} feature flag evaluates to {1}.\n",
-                    FeatureFlagKey, changeArgs.NewValue));
+                    Console.WriteLine("*** The {0} feature flag evaluates to {1}.\n", FeatureFlagKey, changeArgs.NewValue);
 
                     if (changeArgs.NewValue.AsBool) ShowBanner();
                 }

--- a/HelloDotNet/Hello.cs
+++ b/HelloDotNet/Hello.cs
@@ -63,7 +63,7 @@ namespace HelloDotNet
 
             var flagValue = client.BoolVariation(FeatureFlagKey, context, false);
 
-            Console.WriteLine("*** The {0} feature flag evaluates to {1}.\n", FeatureFlagKey, flagValue);
+            Console.WriteLine($"*** The {FeatureFlagKey} feature flag evaluates to {flagValue}.\n");
 
             if (flagValue)
             {
@@ -74,7 +74,7 @@ namespace HelloDotNet
                 FeatureFlagKey,
                 context,
                 (sender, changeArgs) => {
-                    Console.WriteLine("*** The {0} feature flag evaluates to {1}.\n", FeatureFlagKey, changeArgs.NewValue);
+                    Console.WriteLine($"*** The {FeatureFlagKey} feature flag evaluates to {changeArgs.NewValue}.\n");
 
                     if (changeArgs.NewValue.AsBool) ShowBanner();
                 }


### PR DESCRIPTION
Simplify sample server code - `string.Format` is already part of `Console.WriteLine` behavior and natively supports composite formatted strings. 

Could also consider using [string interpolation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated) to make it simpler to read and align with nodeJS getting started `console.log`.